### PR TITLE
Add Latitude and Longitude to Physical::Location

### DIFF
--- a/lib/physical/location.rb
+++ b/lib/physical/location.rb
@@ -18,7 +18,9 @@ module Physical
                 :fax,
                 :email,
                 :address_type,
-                :company_name
+                :company_name,
+                :latitude,
+                :longitude
 
     def initialize(
         name: nil,
@@ -33,7 +35,9 @@ module Physical
         phone: nil,
         fax: nil,
         email: nil,
-        address_type: nil
+        address_type: nil,
+        latitude: nil,
+        longitude: nil
       )
 
       if country.is_a?(Carmen::Country)
@@ -59,6 +63,8 @@ module Physical
       @fax = fax
       @email = email
       @address_type = address_type
+      @latitude = latitude
+      @longitude = longitude
     end
 
     def residential?

--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end

--- a/spec/physical/location_spec.rb
+++ b/spec/physical/location_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Physical::Location do
   it { is_expected.to respond_to(:email) }
   it { is_expected.to respond_to(:address_type) }
   it { is_expected.to respond_to(:company_name) }
+  it { is_expected.to respond_to(:latitude) }
+  it { is_expected.to respond_to(:longitude) }
 
   describe '#country' do
     subject { location.country }


### PR DESCRIPTION
 Up to now, our Location object only had address data. Most addresses
 correspond to a point on earth though, and it's often convenient to have
 somewhere to store that.

