### PR TITLE
Add SKU, cost, and description to items

### DIFF
--- a/lib/physical/item.rb
+++ b/lib/physical/item.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
+require 'money'
+
 module Physical
   class Item < Cuboid
     DEFAULT_LENGTH = 0
+
+    attr_reader :cost
+
+    def initialize(cost: nil, **kwargs)
+      @cost = cost
+      super kwargs
+    end
   end
 end

--- a/lib/physical/item.rb
+++ b/lib/physical/item.rb
@@ -7,11 +7,13 @@ module Physical
     DEFAULT_LENGTH = 0
 
     attr_reader :cost,
-                :sku
+                :sku,
+                :description
 
-    def initialize(cost: nil, sku: nil, **kwargs)
+    def initialize(cost: nil, sku: nil, description: nil, **kwargs)
       @cost = cost
       @sku = sku
+      @description = description
       super kwargs
     end
   end

--- a/lib/physical/item.rb
+++ b/lib/physical/item.rb
@@ -6,10 +6,12 @@ module Physical
   class Item < Cuboid
     DEFAULT_LENGTH = 0
 
-    attr_reader :cost
+    attr_reader :cost,
+                :sku
 
-    def initialize(cost: nil, **kwargs)
+    def initialize(cost: nil, sku: nil, **kwargs)
       @cost = cost
+      @sku = sku
       super kwargs
     end
   end

--- a/lib/physical/item.rb
+++ b/lib/physical/item.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'money'
-
 module Physical
   class Item < Cuboid
     DEFAULT_LENGTH = 0
@@ -11,7 +9,7 @@ module Physical
                 :description
 
     def initialize(cost: nil, sku: nil, description: nil, **kwargs)
-      @cost = cost
+      @cost = Types::Money.optional[cost]
       @sku = sku
       @description = description
       super kwargs

--- a/lib/physical/types.rb
+++ b/lib/physical/types.rb
@@ -1,4 +1,5 @@
 require 'measured'
+require 'money'
 require 'dry-types'
 
 module Physical
@@ -9,6 +10,7 @@ module Physical
     Length = Types.Instance(::Measured::Length)
     Volume = Types.Instance(::Measured::Volume)
     Density = Types.Instance(::Measured::Density)
+    Money = Types.Instance(::Money)
 
     Dimensions = Types::Strict::Array.of(Length)
   end

--- a/physical.gemspec
+++ b/physical.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "carmen", "~> 1.0"
   spec.add_runtime_dependency "measured", "~> 2.4"
   spec.add_runtime_dependency "dry-types", "~> 1.0.0"
+  spec.add_runtime_dependency "money", ">= 5"
 
   spec.add_development_dependency "bundler", [">= 1.16", "< 3"]
   spec.add_development_dependency "factory_bot", "~> 4.8"

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe Physical::Item do
     end
   end
 
+  describe "#cost" do
+    let(:args) { {} }
+
+    subject { described_class.new(args).cost }
+
+    it { is_expected.to be nil }
+
+    context 'if cost is given' do
+      let(:args) { {cost: Money.new(12345, 'USD')} }
+
+      it { is_expected.to eq(Money.new(12345, 'USD')) }
+    end
+  end
+
   describe "#volume" do
     subject { described_class.new(args).volume }
 

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -75,6 +75,20 @@ RSpec.describe Physical::Item do
     end
   end
 
+  describe "#description" do
+    let(:args) { {} }
+
+    subject { described_class.new(args).description }
+
+    it { is_expected.to be nil }
+
+    context 'if description is given' do
+      let(:args) { {description: 'Very Beautiful Earrings'} }
+
+      it { is_expected.to eq('Very Beautiful Earrings') }
+    end
+  end
+
   describe "#volume" do
     subject { described_class.new(args).volume }
 

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe Physical::Item do
     end
   end
 
+  describe "#sku" do
+    let(:args) { {} }
+
+    subject { described_class.new(args).sku }
+
+    it { is_expected.to be nil }
+
+    context 'if sku is given' do
+      let(:args) { {sku: 'my_sku'} }
+
+      it { is_expected.to eq('my_sku') }
+    end
+  end
+
   describe "#volume" do
     subject { described_class.new(args).volume }
 


### PR DESCRIPTION
This gem is meant to operate in an eCommerce context. Rather than relying on the properties Hash and metaprogramming, I think "cost", "sku" and "description" should be first-class attributes of the Physical::Item class.