### PR TITLE
Add double splats for Ruby 2.7 compatibility

### DIFF
--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -14,7 +14,7 @@ module Physical
                 :max_weight
 
     def initialize(inner_dimensions: [], max_weight: Measured::Weight(DEFAULT_MAX_WEIGHT, :g), **args)
-      super args
+      super **args
       @inner_dimensions = fill_dimensions(Types::Dimensions[inner_dimensions])
       @inner_length, @inner_width, @inner_height = *@inner_dimensions
       @max_weight = Types::Weight[max_weight]

--- a/lib/physical/item.rb
+++ b/lib/physical/item.rb
@@ -12,7 +12,7 @@ module Physical
       @cost = Types::Money.optional[cost]
       @sku = sku
       @description = description
-      super kwargs
+      super **kwargs
     end
   end
 end

--- a/lib/physical/spec_support/shared_examples.rb
+++ b/lib/physical/spec_support/shared_examples.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples 'a cuboid' do
   
   describe "#==" do
     let(:args) { Hash[id: 123] }
-    let(:other_cuboid) { described_class.new(args) }
+    let(:other_cuboid) { described_class.new(**args) }
     let(:non_cuboid) { double(id: 123) }
     
     it "compares cuboids" do

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Physical::Box do
-  subject { described_class.new(args) }
+  subject { described_class.new(**args) }
 
   it_behaves_like 'a cuboid'
 
@@ -48,7 +48,7 @@ RSpec.describe Physical::Box do
   end
 
   describe "#volume" do
-    subject { described_class.new(args).volume }
+    subject { described_class.new(**args).volume }
 
     context "if all three dimensions are given" do
       let(:args) { {dimensions: [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :cm) }} }
@@ -68,7 +68,7 @@ RSpec.describe Physical::Box do
   end
 
   describe '#density' do
-    subject { described_class.new(args).density.value.to_f }
+    subject { described_class.new(**args).density.value.to_f }
 
     let(:args) do
       {
@@ -89,7 +89,7 @@ RSpec.describe Physical::Box do
   end
 
   describe "#weight" do
-    subject { described_class.new(args).weight }
+    subject { described_class.new(**args).weight }
 
     context "with no weight given" do
       let(:args) { {} }
@@ -103,7 +103,7 @@ RSpec.describe Physical::Box do
   end
 
   describe "#max_weight" do
-    subject { described_class.new(args).max_weight }
+    subject { described_class.new(**args).max_weight }
 
     context "with no max_weight given" do
       let(:args) { {} }
@@ -126,7 +126,7 @@ RSpec.describe Physical::Box do
   end
 
   describe '#inner_dimensions' do
-    subject { described_class.new(args).inner_dimensions }
+    subject { described_class.new(**args).inner_dimensions }
 
     context 'if all values are given' do
       let(:args) do
@@ -164,7 +164,7 @@ RSpec.describe Physical::Box do
   end
 
   describe 'inner length, width, height, volume' do
-    subject { described_class.new(args) }
+    subject { described_class.new(**args) }
 
     let(:args) do
       {

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Physical::Item do
-  subject(:item) { described_class.new(args) }
+  subject(:item) { described_class.new(**args) }
 
   it_behaves_like 'a cuboid'
 
@@ -50,7 +50,7 @@ RSpec.describe Physical::Item do
   describe "#cost" do
     let(:args) { {} }
 
-    subject { described_class.new(args).cost }
+    subject { described_class.new(**args).cost }
 
     it { is_expected.to be nil }
 
@@ -64,7 +64,7 @@ RSpec.describe Physical::Item do
   describe "#sku" do
     let(:args) { {} }
 
-    subject { described_class.new(args).sku }
+    subject { described_class.new(**args).sku }
 
     it { is_expected.to be nil }
 
@@ -78,7 +78,7 @@ RSpec.describe Physical::Item do
   describe "#description" do
     let(:args) { {} }
 
-    subject { described_class.new(args).description }
+    subject { described_class.new(**args).description }
 
     it { is_expected.to be nil }
 
@@ -90,7 +90,7 @@ RSpec.describe Physical::Item do
   end
 
   describe "#volume" do
-    subject { described_class.new(args).volume }
+    subject { described_class.new(**args).volume }
 
     context "if all three dimensions are given" do
       let(:args) { {dimensions: [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :cm) }} }
@@ -110,7 +110,7 @@ RSpec.describe Physical::Item do
   end
 
   describe "#density" do
-    subject { described_class.new(args).density.value.to_f }
+    subject { described_class.new(**args).density.value.to_f }
 
     let(:args) do
       {
@@ -151,7 +151,7 @@ RSpec.describe Physical::Item do
   end
 
   describe "#weight" do
-    subject { described_class.new(args).weight }
+    subject { described_class.new(**args).weight }
 
     context "with no weight given" do
       let(:args) { {} }

--- a/spec/physical/location_spec.rb
+++ b/spec/physical/location_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Physical::Location do
   let(:args) { {} }
 
-  subject(:location) { described_class.new(args) }
+  subject(:location) { described_class.new(**args) }
 
   it { is_expected.to respond_to(:country) }
   it { is_expected.to respond_to(:zip) }
@@ -85,7 +85,7 @@ RSpec.describe Physical::Location do
   end
   
   describe "==" do
-    let(:other_location) { described_class.new(args) }
+    let(:other_location) { described_class.new(**args) }
     let(:non_location) { double(to_hash: location.to_hash) }
     
     it "compares locations" do

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Physical::Package do
-  subject(:package) { described_class.new(args) }
+  subject(:package) { described_class.new(**args) }
 
   context 'with no args given' do
     let(:args) { {} }
@@ -266,7 +266,7 @@ RSpec.describe Physical::Package do
   end
 
   describe "#density" do
-    subject { described_class.new(args).density.value.to_f }
+    subject { described_class.new(**args).density.value.to_f }
 
     let(:args) do
       {

--- a/spec/physical/shipment_spec.rb
+++ b/spec/physical/shipment_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Physical::Shipment do
   let(:args) { {} }
-  subject(:shipment) { described_class.new(args) }
+  subject(:shipment) { described_class.new(**args) }
 
   describe '#packages' do
     subject { shipment.packages }


### PR DESCRIPTION
☝️ 

Specs run without warnings under Ruby 2.7 (with the exception of incompatible 3rd party libraries).

https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html