### PR TITLE
Explicitly set the Money rounding mode

### DIFF
--- a/lib/physical/types.rb
+++ b/lib/physical/types.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'measured'
-require 'money'
 require 'dry-types'
 
 module Physical

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,10 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
+require "money"
+# Explicitly configure the default rounding mode to avoid deprecation warnings
+Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
+
 require "bundler/setup"
 require "physical"
 require "physical/spec_support/factories"


### PR DESCRIPTION
This eliminates deprecation warnings about the rounding mode for `Money` being changed in the next major release. This also relocates the require statement to a central location since the `Money` class is being used in a lot of different places now.