### PR TITLE
Add option to round dimensions before calculating volume

### DIFF
--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -15,8 +15,11 @@ module Physical
       @properties = properties
     end
 
-    def volume
-      Measured::Volume(dimensions.map { |d| d.convert_to(:cm).value }.reduce(1, &:*), :ml)
+    def volume(round_dimensions: false)
+      dimension_values = dimensions.map { |d| d.convert_to(:cm).value }
+      dimension_values = dimension_values.map(&:round) if round_dimensions
+      volume = dimension_values.reduce(1, &:*)
+      Measured::Volume(volume, :ml)
     end
 
     def density

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -206,6 +206,14 @@ RSpec.describe Physical::Package do
     it 'is the container volume' do
       expect(package.volume).to eq(Measured::Volume(6, :ml))
     end
+
+    describe 'rounding dimensions' do
+      let(:args) { { container: Physical::Box.new(dimensions: [0.5,1.8,3.2].map { |d| Measured::Length(d, :cm)}) } }
+
+      it 'rounds dimensions before calculating volume' do
+        expect(package.volume(round_dimensions: true)).to eq(Measured::Volume(6, :ml))
+      end
+    end
   end
 
   describe "#remaining_volume" do


### PR DESCRIPTION
It's helpful to optionally round decimal dimensions before calculating volume for a cuboid. Consider this a first pass. I'm open to suggestions for a better way to implement this feature.