### PR TITLE
Add RubyMine metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 .rspec_status
 .ruby-version
 Gemfile.lock
+
+# RubyMine
+.idea
+.rakeTasks


### PR DESCRIPTION
This adds RubyMine metadata files to .gitignore so they never get checked into the repo.