### PR TITLE
Move dev dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,3 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in physical.gemspec
 gemspec
-
-group :test do
-  gem 'rspec_junit_formatter'
-  gem 'rubocop'
-  gem 'simplecov', require: false
-end

--- a/physical.gemspec
+++ b/physical.gemspec
@@ -29,4 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_bot", "~> 4.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
This seems like a more appropriate place for development dependencies in a gem vs an app. See: https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/