### PR TITLE
Use FactoryBots loading mechanism for factories

### DIFF
--- a/lib/physical/spec_support/factories.rb
+++ b/lib/physical/spec_support/factories.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+Alchemy::Deprecation.warn <<~MSG
+  Please require factories using FactoryBots preferred approach:
+
+      # spec/rails_helper.rb
+
+      require 'physical/test_support'
+
+      FactoryBot.definition_file_paths.concat(Physical::TestSupport.factory_paths)
+      FactoryBot.reload
+MSG
+
 require 'physical/spec_support/factories/item_factory'
 require 'physical/spec_support/factories/box_factory'
 require 'physical/spec_support/factories/package_factory'

--- a/lib/physical/spec_support/factories/box_factory.rb
+++ b/lib/physical/spec_support/factories/box_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
-
 FactoryBot.define do
   factory :physical_box, class: "Physical::Box" do
     dimensions { [20, 15, 30].map { |d| Measured::Length(d, :cm) } }

--- a/lib/physical/spec_support/factories/item_factory.rb
+++ b/lib/physical/spec_support/factories/item_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
-
 FactoryBot.define do
   factory :physical_item, class: "Physical::Item" do
     dimensions { [1, 2, 3].map { |d| Measured::Length(d, :cm) } }

--- a/lib/physical/spec_support/factories/package_factory.rb
+++ b/lib/physical/spec_support/factories/package_factory.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
-require_relative 'box_factory'
-require_relative 'item_factory'
-
 FactoryBot.define do
   factory :physical_package, class: "Physical::Package" do
     container { FactoryBot.build(:physical_box) }

--- a/lib/physical/spec_support/factories/shipment_factory.rb
+++ b/lib/physical/spec_support/factories/shipment_factory.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
-require_relative 'location_factory'
-require_relative 'package_factory'
-
 FactoryBot.define do
   factory :physical_shipment, class: "Physical::Shipment" do
     origin { FactoryBot.build(:physical_location) }

--- a/lib/physical/test_support.rb
+++ b/lib/physical/test_support.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Physical
+  module TestSupport
+    def self.factory_paths
+      spec = Gem::Specification.find_by_name("physical")
+      root = Pathname.new(spec.gem_dir)
+      Dir[
+        root.join("lib", "physical", "spec_support", "factories", "*_factory.rb")
+      ].map { |path| path.sub(/.rb\z/, "") }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,12 @@ Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
 
 require "bundler/setup"
 require "physical"
-require "physical/spec_support/factories"
 require "physical/spec_support/shared_examples"
+require "factory_bot"
+require "physical/test_support"
+
+FactoryBot.definition_file_paths.concat(Physical::TestSupport.factory_paths)
+FactoryBot.reload
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
We were using `require` before. This allows using FactoryBot's
`definitions` array instead.