### PR TITLE
Adds convenience methods for weight, volume, and fit

### DIFF
--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -26,5 +26,17 @@ module Physical
         :ml
       )
     end
+
+    # @param [Physical::Item] item
+    # @return [Boolean]
+    def item_fits?(item)
+      return false if item.weight > max_weight
+
+      box_dimensions = inner_dimensions.sort
+      item.dimensions.sort.each.with_index do |axis, index|
+        return false if axis >= box_dimensions[index]
+      end
+      true
+    end
   end
 end

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -28,8 +28,13 @@ module Physical
       container.weight + items.map(&:weight).reduce(Measured::Weight(0, :g), &:+) + void_fill_weight
     end
 
+    # @return [Measured::Volume]
+    def used_volume
+      items.map(&:volume).reduce(Measured::Volume(0, :ml), &:+)
+    end
+
     def remaining_volume
-      container.inner_volume - items.map(&:volume).reduce(Measured::Volume(0, :ml), &:+)
+      container.inner_volume - used_volume
     end
 
     def void_fill_weight

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -25,7 +25,18 @@ module Physical
     alias_method :delete, :>>
 
     def weight
-      container.weight + items.map(&:weight).reduce(Measured::Weight(0, :g), &:+) + void_fill_weight
+      container.weight + items_weight + void_fill_weight
+    end
+
+    # @return [Measured::Weight]
+    def items_weight
+      items.map(&:weight).reduce(Measured::Weight(0, :g), &:+)
+    end
+
+    def void_fill_weight
+      return Measured::Weight(0, :g) if container.volume.value.infinite?
+
+      Measured::Weight(void_fill_density.convert_to(:g_ml).value * remaining_volume.convert_to(:ml).value, :g)
     end
 
     # @return [Measured::Volume]
@@ -35,12 +46,6 @@ module Physical
 
     def remaining_volume
       container.inner_volume - used_volume
-    end
-
-    def void_fill_weight
-      return Measured::Weight(0, :g) if container.volume.value.infinite?
-
-      Measured::Weight(void_fill_density.convert_to(:g_ml).value * remaining_volume.convert_to(:ml).value, :g)
     end
 
     def density

--- a/lib/physical/pallet.rb
+++ b/lib/physical/pallet.rb
@@ -13,5 +13,17 @@ module Physical
       super(**args)
       @max_weight = Types::Weight[max_weight]
     end
+
+    # @param [Physical::Package] package
+    # @return [Boolean]
+    def package_fits?(package)
+      return false if package.weight > max_weight
+
+      pallet_dimensions = dimensions.sort
+      package.dimensions.sort.each.with_index do |axis, index|
+        return false if axis >= pallet_dimensions.sort[index]
+      end
+      true
+    end
   end
 end

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -182,4 +182,47 @@ RSpec.describe Physical::Box do
       end
     end
   end
+
+  describe "#item_fits?" do
+    let(:args) do
+      {
+        dimensions: [15, 10, 5].map { |d| Measured::Length(d, :cm) },
+        max_weight: Measured::Weight(5, :g)
+      }
+    end
+
+    subject { described_class.new(**args).item_fits?(item) }
+
+    context "with item that fits" do
+      let(:item) do
+        Physical::Item.new(
+          dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) },
+          weight: Measured::Weight(3, :g)
+        )
+      end
+      it { is_expected.to be(true) }
+    end
+
+    context "with item that is too big" do
+      let(:item) do
+        Physical::Item.new(
+          dimensions: [20, 15, 10].map { |d| Measured::Length(d, :cm) },
+          weight: Measured::Weight(3, :g)
+        )
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "with item that is too heavy" do
+      let(:item) do
+        Physical::Item.new(
+          dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) },
+          weight: Measured::Weight(10, :g)
+        )
+      end
+
+      it { is_expected.to be(false) }
+    end
+  end
 end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -208,6 +208,18 @@ RSpec.describe Physical::Package do
     end
   end
 
+  describe "#used_volume" do
+    let(:args) do
+      {
+        items: Physical::Item.new(dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) })
+      }
+    end
+
+    subject { package.used_volume }
+
+    it { is_expected.to eq(Measured::Volume(1, :ml)) }
+  end
+
   describe "#remaining_volume" do
     let(:args) do
       {

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -190,6 +190,41 @@ RSpec.describe Physical::Package do
     end
   end
 
+  describe '#items_weight' do
+    let(:args) do
+      {
+        items: [
+          Physical::Item.new(weight: Measured::Weight(0.2, :lb)),
+          Physical::Item.new(weight: Measured::Weight(1, :lb))
+        ]
+      }
+    end
+
+    subject { package.items_weight }
+
+    it { is_expected.to eq(Measured::Weight(544.310844, :g)) }
+  end
+
+  describe '#void_fill_weight' do
+    subject { package.void_fill_weight }
+
+    context 'when void fill density is given' do
+      let(:container) do
+        Physical::Box.new(
+          dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) },
+          inner_dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) }
+        )
+      end
+
+      let(:args) { { container: container, void_fill_density: Measured::Density.new(0.007, :g_ml) } }
+
+      it 'calculates the void fill weight from inner dimensions' do
+        is_expected.to be_a(Measured::Weight)
+        expect(subject.convert_to(:g).value.to_f).to eq(0.007)
+      end
+    end
+  end
+
   describe 'dimension methods' do
     let(:args) { { container: Physical::Box.new(dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) }) } }
 
@@ -254,26 +289,6 @@ RSpec.describe Physical::Package do
 
     it 'has plausible attributes' do
       expect(subject.weight).to eq(Measured::Weight(277.02, :g))
-    end
-  end
-
-  describe '#void_fill_weight' do
-    subject { package.void_fill_weight }
-
-    context 'when void fill density is given' do
-      let(:container) do
-        Physical::Box.new(
-          dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) },
-          inner_dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) }
-        )
-      end
-
-      let(:args) { { container: container, void_fill_density: Measured::Density.new(0.007, :g_ml) } }
-
-      it 'calculates the void fill weight from inner dimensions' do
-        is_expected.to be_a(Measured::Weight)
-        expect(subject.convert_to(:g).value.to_f).to eq(0.007)
-      end
     end
   end
 

--- a/spec/physical/pallet_spec.rb
+++ b/spec/physical/pallet_spec.rb
@@ -124,4 +124,47 @@ RSpec.describe Physical::Pallet do
       expect(subject.weight.convert_to(:kg).value).to eq(22)
     end
   end
+
+  describe "#package_fits?" do
+    let(:args) do
+      {
+        dimensions: [165, 120, 80].map { |d| Measured::Length(d, :cm) },
+        max_weight: Measured::Weight(2000, :lbs)
+      }
+    end
+
+    subject { described_class.new(**args).package_fits?(package) }
+
+    context "with package that fits" do
+      let(:package) do
+        Physical::Package.new(
+          dimensions: [50, 40, 25].map { |d| Measured::Length(d, :cm) },
+          weight: Measured::Weight(100, :lbs)
+        )
+      end
+      it { is_expected.to be(true) }
+    end
+
+    context "with package that is too big" do
+      let(:package) do
+        Physical::Package.new(
+          dimensions: [200, 150, 120].map { |d| Measured::Length(d, :cm) },
+          weight: Measured::Weight(100, :lbs)
+        )
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "with package that is too heavy" do
+      let(:package) do
+        Physical::Package.new(
+          dimensions: [50, 40, 25].map { |d| Measured::Length(d, :cm) },
+          weight: Measured::Weight(2500, :lbs)
+        )
+      end
+
+      it { is_expected.to be(false) }
+    end
+  end
 end


### PR DESCRIPTION
This adds new methods to the `Package`, `Box`, and `Pallet` classes.

`#used_volume` calculates the amount of volume used by all items in a package
`#items_weight` calculates the weight of all items in a package (exclusive of void fill or container weight)
`#item_fits?` determines if a given `Item` fits into a `Box` (by weight and dimension)
`#package_fits?` determines if a given `Package` fits onto a `Pallet` (by weight and dimension)