### PR TITLE
Alias inner dimensions for `Pallet` class

### DIFF
--- a/lib/physical/pallet.rb
+++ b/lib/physical/pallet.rb
@@ -14,6 +14,12 @@ module Physical
       @max_weight = Types::Weight[max_weight]
     end
 
+    alias_method :inner_volume, :volume
+    alias_method :inner_dimensions, :dimensions
+    alias_method :inner_length, :length
+    alias_method :inner_width, :width
+    alias_method :inner_height, :height
+
     # @param [Physical::Package] package
     # @return [Boolean]
     def package_fits?(package)

--- a/spec/physical/pallet_spec.rb
+++ b/spec/physical/pallet_spec.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Physical::Pallet do
+  let(:args) { {} }
   subject { described_class.new(**args) }
 
   it_behaves_like 'a cuboid'
+
+  it { is_expected.to respond_to(:inner_volume) }
+  it { is_expected.to respond_to(:inner_dimensions) }
+  it { is_expected.to respond_to(:inner_length) }
+  it { is_expected.to respond_to(:inner_width) }
+  it { is_expected.to respond_to(:inner_height) }
 
   context "when given a one-element dimensions array" do
     let(:args) { { dimensions: [Measured::Length(2, :cm)] } }


### PR DESCRIPTION
This adds aliases for inner dimensions to the `Pallet` class. The `Package` class calls `#inner_volume` when calculating remaining volume, and since a `Pallet` is intended to be used as the container for a `Package`, we need to respond to the method even though a `Pallet` doesn't actually have inner dimensions.