### PR TITLE
Update dry-types to 1.5.1

### DIFF
--- a/physical.gemspec
+++ b/physical.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.4'
   spec.add_runtime_dependency "carmen", "~> 1.0"
-  spec.add_runtime_dependency "dry-types", "~> 1.0.0"
+  spec.add_runtime_dependency "dry-types", "~> 1.5.1"
   spec.add_runtime_dependency "measured", "~> 2.4"
   spec.add_runtime_dependency "money", ">= 5"
 


### PR DESCRIPTION
This fixes keyword args for Ruby 3.0