### PR TITLE
Physical::Package Items Value

### DIFF
--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -28,6 +28,14 @@ module Physical
       container.weight + items_weight + void_fill_weight
     end
 
+    # Cost is optional. We will only return an aggregate if all items
+    # have cost defined. Otherwise we will retun nil.
+    # @return Money
+    def items_value
+      items_cost = items.map(&:cost)
+      items_cost.reduce(&:+) if items_cost.compact.size == items_cost.size
+    end
+
     # @return [Measured::Weight]
     def items_weight
       items.map(&:weight).reduce(Measured::Weight(0, :g), &:+)

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -190,6 +190,53 @@ RSpec.describe Physical::Package do
     end
   end
 
+  describe '#items_value' do
+    subject { package.items_value}
+
+    context 'without items' do
+      let(:args) {{ items: [] }}
+      it { is_expected.to be_nil }
+    end
+
+    context 'without cost defined for items' do
+      let(:args) do
+        {
+          items: [
+            Physical::Item.new(weight: Measured::Weight(0.2, :lb)),
+            Physical::Item.new(weight: Measured::Weight(1, :lb))
+          ]
+        }
+      end
+      it { is_expected.to be_nil }
+    end
+
+    context 'with cost sparsely defined for items' do
+      let(:args) do
+        {
+          items: [
+            Physical::Item.new(weight: Measured::Weight(0.2, :lb), cost: Money.new(12_345, 'USD')),
+            Physical::Item.new(weight: Measured::Weight(1, :lb))
+          ]
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with cost defined for all items' do
+      let(:args) do
+        {
+          items: [
+            Physical::Item.new(weight: Measured::Weight(0.2, :lb), cost: Money.new(12_345, 'USD')),
+            Physical::Item.new(weight: Measured::Weight(1, :lb), cost: Money.new(12_345, 'USD'))
+          ]
+        }
+      end
+
+      it { is_expected.to eq(Money.new(24690, 'USD')) }
+    end
+  end
+
   describe '#items_weight' do
     let(:args) do
       {


### PR DESCRIPTION
# Description

Some services that take a physical package want to know the value of the contents of the package. Aggregate the cost of the items and return for #items_value. Item cost is optional. If any item doesn't have a cost return nil for Package#items_value so we don't provide partial value.

## Example of usuage
USPS International Shipping requires ValueOfContents when quoting. 

<img width="760" alt="Screen Shot" src="https://user-images.githubusercontent.com/503436/224035158-6837532e-68c1-4d17-8e6d-9a9776200b28.png">

[Source](https://www.usps.com/business/web-tools-apis/rate-calculator-api.pdf)
