### PR TITLE
Allow shipments to have pallets

### DIFF
--- a/lib/physical/shipment.rb
+++ b/lib/physical/shipment.rb
@@ -6,14 +6,16 @@ module Physical
                 :origin,
                 :destination,
                 :service_code,
+                :pallets,
                 :packages,
                 :options
 
-    def initialize(id: nil, origin: nil, destination: nil, service_code: nil, packages: [], options: {})
+    def initialize(id: nil, origin: nil, destination: nil, service_code: nil, pallets: [], packages: [], options: {})
       @id = id || SecureRandom.uuid
       @origin = origin
       @destination = destination
       @service_code = service_code
+      @pallets = pallets
       @packages = packages
       @options = options
     end

--- a/lib/physical/spec_support/factories/shipment_factory.rb
+++ b/lib/physical/spec_support/factories/shipment_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :physical_shipment, class: "Physical::Shipment" do
     origin { FactoryBot.build(:physical_location) }
     destination { FactoryBot.build(:physical_location) }
+    pallets { build_list(:physical_pallet, 1) }
     packages { build_list(:physical_package, 2) }
     service_code { "usps_priority_mail" }
     initialize_with { new(**attributes) }

--- a/spec/physical/shipment_spec.rb
+++ b/spec/physical/shipment_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Physical::Shipment do
   let(:args) { {} }
   subject(:shipment) { described_class.new(**args) }
 
+  describe '#pallets' do
+    subject { shipment.pallets }
+
+    it { is_expected.to eq([]) }
+  end
+
   describe '#packages' do
     subject { shipment.packages }
 
@@ -40,6 +46,7 @@ RSpec.describe Physical::Shipment do
     it "works" do
       expect(subject.origin).to be_a(Physical::Location)
       expect(subject.destination).to be_a(Physical::Location)
+      expect(subject.pallets.length).to eq(1)
       expect(subject.packages.length).to eq(2)
       expect(subject.service_code).to eq("usps_priority_mail")
     end


### PR DESCRIPTION
This adds a pallets attribute to `Physical::Shipment` to enable shipments to be created with pallets and packages. The idea is to enable modeling a variety of shipments, including those that may consist of pallets (each containing its own packages) and also standalone packages that aren't packed onto a pallet.