### PR TITLE
Use legitimate state/zip in location factory

### DIFF
--- a/lib/physical/spec_support/factories/location_factory.rb
+++ b/lib/physical/spec_support/factories/location_factory.rb
@@ -4,15 +4,15 @@ FactoryBot.define do
   factory :physical_location, class: 'Physical::Location' do
     transient do
       country_code { 'US' }
-      region_code { 'IL' }
+      region_code { 'VA' }
     end
 
     name { 'Jane Doe' }
     company_name { 'Company' }
     address1 { '11 Lovely Street' }
-    address2 { 'South' }
+    address2 { 'Suite 100' }
     city { 'Herndon' }
-    sequence(:zip, 10_001, &:to_s)
+    zip { '20170' }
     phone { '555-555-0199' }
     email { 'jane@company.com' }
     region { country.subregions.coded(region_code) }

--- a/spec/physical/location_spec.rb
+++ b/spec/physical/location_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Physical::Location do
 
   describe 'factory' do
     let(:country) { Carmen::Country.coded('us') }
-    let(:subregion) { country.subregions.coded('il') }
+    let(:subregion) { country.subregions.coded('va') }
 
     subject { FactoryBot.build(:physical_location) }
 
@@ -110,7 +110,7 @@ RSpec.describe Physical::Location do
       expect(subject.region).to eq(subregion)
       expect(subject.name).to eq("Jane Doe")
       expect(subject.address1).to eq("11 Lovely Street")
-      expect(subject.address2).to eq("South")
+      expect(subject.address2).to eq("Suite 100")
       expect(subject.address3).to be_nil
       expect(subject.city).to eq("Herndon")
       expect(subject.company_name).to eq("Company")
@@ -124,7 +124,7 @@ RSpec.describe Physical::Location do
     it do
       is_expected.to match(
         hash_including(
-          region: 'IL'
+          region: 'VA'
         )
       )
     end


### PR DESCRIPTION
This updates the location factory to create locations with a legitimate state/zip combination. The previous state and zip did not match each other and did not match the city name (Herndon) either.

When using this location factory outside the `physical` gem it's helpful to have city/state/zip match since third party APIs (for example, shipping carriers) will often validate this information.