### PR TITLE
Introduce `Physical::Structure` class

### DIFF
--- a/lib/physical.rb
+++ b/lib/physical.rb
@@ -12,6 +12,7 @@ require "physical/pallet"
 require "physical/item"
 require "physical/location"
 require "physical/shipment"
+require "physical/structure"
 
 module Physical
   # Your code goes here...

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -3,12 +3,13 @@
 module Physical
   class Package
     extend Forwardable
-    attr_reader :id, :container, :items, :void_fill_density, :items_weight, :used_volume
+    attr_reader :id, :container, :items, :void_fill_density, :items_weight, :used_volume, :description
 
-    def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Density(0, :g_ml), dimensions: nil, weight: nil, properties: {})
+    def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Density(0, :g_ml), dimensions: nil, weight: nil, description: nil, properties: {})
       @id = id || SecureRandom.uuid
       @void_fill_density = Types::Density[void_fill_density]
       @container = container || Physical::Box.new(dimensions: dimensions || [], weight: weight || Measured::Weight(0, :g), properties: properties)
+      @description = description
 
       @items = Set[*items]
       @items_weight = @items.map(&:weight).reduce(Measured::Weight(0, :g), &:+)

--- a/lib/physical/shipment.rb
+++ b/lib/physical/shipment.rb
@@ -7,17 +7,23 @@ module Physical
                 :destination,
                 :service_code,
                 :pallets,
+                :structures,
                 :packages,
                 :options
 
-    def initialize(id: nil, origin: nil, destination: nil, service_code: nil, pallets: [], packages: [], options: {})
+    def initialize(id: nil, origin: nil, destination: nil, service_code: nil, pallets: [], structures: [], packages: [], options: {})
       @id = id || SecureRandom.uuid
       @origin = origin
       @destination = destination
       @service_code = service_code
-      @pallets = pallets
+      @structures = structures
       @packages = packages
       @options = options
+
+      return unless pallets.any?
+
+      warn "[DEPRECATION] `pallets` is deprecated.  Please use `structures` instead."
+      @pallets = pallets
     end
   end
 end

--- a/lib/physical/spec_support/factories/shipment_factory.rb
+++ b/lib/physical/spec_support/factories/shipment_factory.rb
@@ -4,9 +4,14 @@ FactoryBot.define do
   factory :physical_shipment, class: "Physical::Shipment" do
     origin { FactoryBot.build(:physical_location) }
     destination { FactoryBot.build(:physical_location) }
-    pallets { build_list(:physical_pallet, 1) }
+    pallets { build_list(:physical_pallet, 1) } # deprecated, will be removed
     packages { build_list(:physical_package, 2) }
     service_code { "usps_priority_mail" }
     initialize_with { new(**attributes) }
+
+    trait :freight do
+      structures { build_list(:physical_structure, 1) }
+      service_code { "tforce_freight" }
+    end
   end
 end

--- a/lib/physical/spec_support/factories/structure_factory.rb
+++ b/lib/physical/spec_support/factories/structure_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :physical_structure, class: "Physical::Structure" do
+    container { FactoryBot.build(:physical_pallet) }
+    packages { build_list(:physical_package, 2) }
+    initialize_with { new(**attributes) }
+  end
+end

--- a/lib/physical/structure.rb
+++ b/lib/physical/structure.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Physical
+  class Structure
+    extend Forwardable
+    attr_reader :id, :container, :packages, :packages_weight, :used_volume
+
+    def initialize(id: nil, container: nil, packages: [], dimensions: nil, weight: nil, properties: {})
+      @id = id || SecureRandom.uuid
+      @container = container || Physical::Pallet.new(dimensions: dimensions || [], weight: weight || Measured::Weight(0, :g), properties: properties)
+
+      @packages = Set[*packages]
+      @packages_weight = @packages.map(&:weight).reduce(Measured::Weight(0, :g), &:+)
+      @used_volume = @packages.map(&:volume).reduce(Measured::Volume(0, :ml), &:+)
+    end
+
+    delegate [:dimensions, :width, :length, :height, :properties, :volume] => :container
+
+    def <<(other)
+      @packages.add(other)
+      @packages_weight += other.weight
+      @used_volume += other.volume
+    end
+    alias_method :add, :<<
+
+    def >>(other)
+      @packages.delete(other)
+      @packages_weight -= other.weight
+      @used_volume -= other.volume
+    end
+    alias_method :delete, :>>
+
+    def weight
+      container.weight + packages_weight
+    end
+
+    # Cost is optional. We will only return an aggregate if all packages
+    # have items value defined. Otherwise we will return nil.
+    # @return Money
+    def packages_value
+      packages_cost = packages.map(&:items_value)
+      packages_cost.reduce(&:+) if packages_cost.compact.size == packages_cost.size
+    end
+
+    def remaining_volume
+      container.inner_volume - used_volume
+    end
+
+    def density
+      return Measured::Density(Float::INFINITY, :g_ml) if container.volume.value.zero?
+      return Measured::Density(0.0, :g_ml) if container.volume.value.infinite?
+
+      Measured::Density(weight.convert_to(:g).value / container.volume.convert_to(:ml).value, :g_ml)
+    end
+  end
+end

--- a/spec/measured/density_spec.rb
+++ b/spec/measured/density_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Measured::Density do
   it "has a SI unit" do
     expect(Measured::Density(1, :kg_m3).unit).to be_a(Measured::Unit)

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -190,6 +190,20 @@ RSpec.describe Physical::Package do
     end
   end
 
+  describe "#description" do
+    let(:args) { {} }
+
+    subject { described_class.new(**args).description }
+
+    it { is_expected.to be nil }
+
+    context "if description is given" do
+      let(:args) { { description: "Very Beautiful Earrings" } }
+
+      it { is_expected.to eq("Very Beautiful Earrings") }
+    end
+  end
+
   describe '#items_value' do
     subject { package.items_value }
 

--- a/spec/physical/shipment_spec.rb
+++ b/spec/physical/shipment_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Physical::Shipment do
   let(:args) { {} }
   subject(:shipment) { described_class.new(**args) }
 
-  describe '#pallets' do
-    subject { shipment.pallets }
+  describe '#structures' do
+    subject { shipment.structures }
 
     it { is_expected.to eq([]) }
   end
@@ -40,15 +40,36 @@ RSpec.describe Physical::Shipment do
     it { is_expected.to eq({}) }
   end
 
-  describe 'factory' do
+  describe '#packages' do
+    subject { shipment.packages }
+
+    let(:args) { { packages: packages } }
+    let(:packages) { [Physical::Package.new(id: "1"), Physical::Package.new(id: "2")] }
+
+    it { is_expected.to eq(packages) }
+  end
+
+  describe "factory" do
     subject { FactoryBot.build(:physical_shipment) }
 
     it "works" do
       expect(subject.origin).to be_a(Physical::Location)
       expect(subject.destination).to be_a(Physical::Location)
-      expect(subject.pallets.length).to eq(1)
+      expect(subject.structures).to be_empty
       expect(subject.packages.length).to eq(2)
       expect(subject.service_code).to eq("usps_priority_mail")
+    end
+
+    describe "freight" do
+      subject { FactoryBot.build(:physical_shipment, :freight) }
+
+      it "works" do
+        expect(subject.origin).to be_a(Physical::Location)
+        expect(subject.destination).to be_a(Physical::Location)
+        expect(subject.structures.length).to eq(1)
+        expect(subject.packages.length).to eq(2)
+        expect(subject.service_code).to eq("tforce_freight")
+      end
     end
   end
 end

--- a/spec/physical/structure_spec.rb
+++ b/spec/physical/structure_spec.rb
@@ -1,0 +1,423 @@
+# frozen_string_literal: true
+
+RSpec.describe Physical::Structure do
+  subject(:structure) { described_class.new(**args) }
+
+  context 'with no args given' do
+    let(:args) { {} }
+
+    it "has no packages" do
+      expect(subject.packages).to be_empty
+    end
+
+    it "is an infitely large pallet" do
+      expect(subject.container).to be_a(Physical::Pallet)
+      expect(subject.dimensions).to eq(
+        [Measured::Length.new(BigDecimal::INFINITY, :cm)] * 3
+      )
+    end
+  end
+
+  describe "#packages" do
+    let(:args) { {} }
+
+    subject { structure.packages }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe "#<<" do
+    let(:args) { {} }
+    let(:package) { Physical::Package.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) }) }
+
+    subject { structure.packages }
+
+    before do
+      structure << package
+    end
+
+    it { is_expected.to contain_exactly(package) }
+
+    context 'with a package already present' do
+      let(:args) { { packages: [package] } }
+
+      before do
+        structure << package
+      end
+
+      it { is_expected.to contain_exactly(package) }
+    end
+  end
+
+  describe "#add" do
+    let(:args) { {} }
+    let(:package) { Physical::Package.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) }) }
+
+    subject { structure.packages }
+
+    before do
+      structure.add(package)
+    end
+
+    it { is_expected.to contain_exactly(package) }
+
+    context 'with a package already present' do
+      let(:args) { { packages: [package] } }
+
+      before do
+        structure.add(package)
+      end
+
+      it { is_expected.to contain_exactly(package) }
+    end
+  end
+
+  describe "#>>" do
+    let(:args) { { packages: [package] } }
+    let(:package) { Physical::Package.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) }) }
+
+    subject { structure.packages }
+
+    before do
+      structure >> package
+    end
+
+    it { is_expected.to be_empty }
+  end
+
+  describe "#delete" do
+    let(:args) { { packages: [package] } }
+    let(:package) { Physical::Package.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) }) }
+
+    subject { structure.packages }
+
+    before do
+      structure.delete(package)
+    end
+
+    it { is_expected.to be_empty }
+  end
+
+  describe "#weight" do
+    let(:args) do
+      {
+        container: Physical::Pallet.new(weight: Measured::Weight(0.8, :lb)),
+        packages: [
+          Physical::Package.new(weight: Measured::Weight(0.2, :lb)),
+          Physical::Package.new(weight: Measured::Weight(1, :lb))
+        ]
+      }
+    end
+
+    subject { structure.weight }
+
+    it "adds the weight of the container with that of the packages" do
+      expect(subject).to eq(Measured::Weight(2, :lb))
+    end
+
+    context 'if no packages given' do
+      let(:args) do
+        {
+          container: Physical::Pallet.new(weight: Measured::Weight(0.8, :lb)),
+          packages: []
+        }
+      end
+
+      it "does not blow up" do
+        expect(subject).to eq(Measured::Weight(0.8, :lb))
+      end
+    end
+
+    context 'with no container given but weight given' do
+      let(:args) do
+        {
+          weight: Measured::Weight(0.8, :lb),
+        }
+      end
+
+      it 'keeps that weight and has infinite dimensions' do
+        expect(structure.weight).to eq(Measured::Weight(0.8, :lb))
+        expect(structure.length).to eq(Measured::Length(Float::INFINITY, :cm))
+        expect(structure.width).to eq(Measured::Length(Float::INFINITY, :cm))
+        expect(structure.height).to eq(Measured::Length(Float::INFINITY, :cm))
+      end
+    end
+
+    context 'with no container given but dimensions given' do
+      let(:args) do
+        {
+          dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) },
+        }
+      end
+
+      it 'keeps that weight and has infinite dimensions' do
+        expect(structure.length).to eq(Measured::Length(1, :cm))
+        expect(structure.width).to eq(Measured::Length(2, :cm))
+        expect(structure.height).to eq(Measured::Length(3, :cm))
+        expect(structure.weight).to eq(Measured::Weight(0, :lb))
+      end
+    end
+
+    context 'with no container given but dimensions and weight given' do
+      let(:args) do
+        {
+          weight: Measured::Weight(0.8, :lb),
+          dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) },
+        }
+      end
+
+      it 'keeps that weight and has infinite dimensions' do
+        expect(structure.weight).to eq(Measured::Weight(0.8, :lb))
+        expect(structure.length).to eq(Measured::Length(1, :cm))
+        expect(structure.width).to eq(Measured::Length(2, :cm))
+        expect(structure.height).to eq(Measured::Length(3, :cm))
+      end
+    end
+
+    context 'with properties directly given' do
+      let(:args) do
+        {
+          properties: { foo: :bar }
+        }
+      end
+
+      it 'stores the properties on the container' do
+        aggregate_failures do
+          expect(structure.properties).to eq(foo: :bar)
+          expect(structure.container.properties).to eq(foo: :bar)
+        end
+      end
+    end
+  end
+
+  describe '#packages_value' do
+    subject { structure.packages_value }
+
+    context 'without packages' do
+      let(:args) { { packages: [] } }
+      it { is_expected.to be_nil }
+    end
+
+    context 'without cost defined for packages' do
+      let(:args) do
+        {
+          packages: [
+            Physical::Package.new(weight: Measured::Weight(0.2, :lb)),
+            Physical::Package.new(weight: Measured::Weight(1, :lb))
+          ]
+        }
+      end
+      it { is_expected.to be_nil }
+    end
+
+    context 'with cost sparsely defined for packages' do
+      let(:args) do
+        {
+          packages: [
+            Physical::Package.new(
+              weight: Measured::Weight(0.2, :lb),
+              items: [Physical::Item.new(cost: Money.new(12_345, 'USD'))]
+            ),
+            Physical::Package.new(weight: Measured::Weight(1, :lb))
+          ]
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with cost defined for all packages' do
+      let(:args) do
+        {
+          packages: [
+            Physical::Package.new(
+              weight: Measured::Weight(0.2, :lb),
+              items: [Physical::Item.new(cost: Money.new(12_345, 'USD'))]
+            ),
+            Physical::Package.new(
+              weight: Measured::Weight(1, :lb),
+              items: [Physical::Item.new(cost: Money.new(12_345, 'USD'))]
+            )
+          ]
+        }
+      end
+
+      it { is_expected.to eq(Money.new(24_690, 'USD')) }
+    end
+  end
+
+  describe "#packages_weight" do
+    let(:args) do
+      {
+        packages: [
+          Physical::Package.new(weight: Measured::Weight(0.2, :g)),
+          Physical::Package.new(weight: Measured::Weight(1, :g))
+        ]
+      }
+    end
+
+    subject { structure.packages_weight }
+
+    it { is_expected.to eq(Measured::Weight(1.2, :g)) }
+
+    context "after adding packages to the structure" do
+      before do
+        structure << Physical::Package.new(weight: Measured::Weight(2, :g))
+      end
+
+      it { is_expected.to eq(Measured::Weight(3.2, :g)) }
+    end
+
+    context "after removing packages from the structure" do
+      before do
+        structure >> Physical::Package.new(weight: Measured::Weight(1, :g))
+      end
+
+      it { is_expected.to eq(Measured::Weight(0.2, :g)) }
+    end
+  end
+
+  describe 'dimension methods' do
+    let(:args) { { container: Physical::Pallet.new(dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) }) } }
+
+    it 'forwards them to the container' do
+      expect(structure.length).to eq(Measured::Length(1, :cm))
+      expect(structure.width).to eq(Measured::Length(2, :cm))
+      expect(structure.height).to eq(Measured::Length(3, :cm))
+    end
+  end
+
+  describe '#volume' do
+    let(:args) { { container: Physical::Pallet.new(dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) }) } }
+
+    it 'is the container volume' do
+      expect(structure.volume).to eq(Measured::Volume(6, :ml))
+    end
+  end
+
+  describe "#used_volume" do
+    let(:args) do
+      {
+        packages: [
+          Physical::Package.new(dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) }),
+          Physical::Package.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) })
+        ]
+      }
+    end
+
+    subject { structure.used_volume }
+
+    it { is_expected.to eq(Measured::Volume(9, :ml)) }
+
+    context "after adding packages to the structure" do
+      before do
+        structure << Physical::Package.new(dimensions: [3, 3, 3].map { |d| Measured::Length(d, :cm) })
+      end
+
+      it { is_expected.to eq(Measured::Volume(36, :ml)) }
+    end
+
+    context "after removing packages from the structure" do
+      before do
+        structure >> Physical::Package.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) })
+      end
+
+      it { is_expected.to eq(Measured::Volume(1, :ml)) }
+    end
+  end
+
+  describe "#remaining_volume" do
+    let(:args) do
+      {
+        container: Physical::Pallet.new(dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) }),
+        packages: Physical::Package.new(dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) })
+      }
+    end
+
+    subject { structure.remaining_volume }
+
+    it { is_expected.to eq(Measured::Volume(5, :ml)) }
+  end
+
+  describe "#id" do
+    subject { structure.id }
+
+    context "id is given" do
+      let(:args) { { id: "12345" } }
+
+      it { is_expected.to eq("12345") }
+    end
+
+    context "no ID is given" do
+      let(:args) { {} }
+
+      it { is_expected.to be_present }
+    end
+  end
+
+  describe 'factory' do
+    subject { FactoryBot.build(:physical_structure) }
+
+    it 'has plausible attributes' do
+      expect(subject.weight).to eq(Measured::Weight(22.55404, :kg))
+    end
+  end
+
+  describe "#density" do
+    subject { described_class.new(**args).density.value.to_f }
+
+    let(:args) do
+      {
+        container: Physical::Pallet.new(
+          dimensions: dimensions
+        ),
+        packages: [
+          Physical::Package.new(
+            dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) },
+            weight: weight
+          )
+        ]
+      }
+    end
+
+    context "if container volume is larger than 0" do
+      let(:dimensions) do
+        [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :in) }
+      end
+
+      context "if packages weight is 1" do
+        let(:weight) { Measured::Weight(1, :pound) }
+
+        it "returns the density in gramms per cubiq centimeter (ml)" do
+          is_expected.to eq(3.7445758536530196)
+        end
+      end
+
+      context "if packages weight is 0" do
+        let(:weight) { Measured::Weight(0, :pound) }
+
+        it { is_expected.to eq(0.0) }
+      end
+    end
+
+    context "if container volume is 0" do
+      let(:dimensions) do
+        [0, 0, 0].map { |d| Measured::Length(d, :in) }
+      end
+
+      let(:weight) { Measured::Weight(1, :pound) }
+
+      it { is_expected.to eq(Float::INFINITY) }
+    end
+
+    context "if container volume is infinite" do
+      let(:dimensions) do
+        [1, 2].map { |d| Measured::Length(d, :in) }
+      end
+
+      let(:weight) { Measured::Weight(1, :pound) }
+
+      it { is_expected.to eq(0.0) }
+    end
+  end
+end


### PR DESCRIPTION
It's been bothering me that our `Physical::Pallet` class acts like a box/cuboid and can't actually hold packages itself. It has to be set as the container on a `Physical::Package` instead.

This leaves us with only one way to model shipments with a pallet having multiple packages:

```ruby
Physical::Package.new( # this is the pallet
  container: Physical::Pallet.new,
  items: [
    Physical::Package.new(
      container: Physical::Box.new,
      items: [
        Physical::Item.new,
        Physical::Item.new
      ]
    )
  ]
)
```

I'm finding this confusing, especially since I essentially have to call `package.items` to get a pallet's packages. I made a mistake adding pallets to shipments in #29.

I think what we need is a `Physical::Package` equivalent for pallets, skids, etc. that can accept the `Physical::Pallet` box/cuboid as the container and can hold multiple `Physical::Package` instances.

The best name I could come up with was "structure." I'm open to suggestions for better names.

Having a `Physical::Structure` which acts similarly to a `Physical::Package` (except it holds packages instead of items) enables us to model a pallet with multiple packages this way:

```ruby
Physical::Structure.new(
  container: Physical::Pallet.new,
  packages: [
    Physical::Package.new(
      container: Physical::Box.new,
      items: [
        Physical::Item.new,
        Physical::Item.new
      ]
    )
  ]
)
```

This has a few benefits. First, the class representing the pallet is _not_ called `Physical::Package` which was confusing before. Second, I can access packages within a pallet by calling `#packages` instead of `#items` (which again was confusing). Third, whenever we want to introduce a new cuboid like `Physical::Skid` we can do so without adding a new arg to `Physical::Shipment` since the skid can easily be set as a structure's container.

I believe these changes will improve the readability and comprehension of our code when modeling shipments involving multiple pallets, each of which contain multiple packages.