### PR TITLE
Install and configure yardstick

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,17 @@ jobs:
           name: run Rubocop
           command: bundle exec rubocop
 
+      - run:
+          name: measure YARD coverage
+          command: bundle exec rake yardstick_measure
+      - store_artifacts:
+          path: /tmp/yard-results
+          destination: yard-results
+
+      - run:
+          name: verify YARD coverage
+          command: bundle exec rake yardstick_verify
+
       # run tests!
       - run:
           name: run tests

--- a/.yardstick.yml
+++ b/.yardstick.yml
@@ -1,0 +1,2 @@
+threshold: 50
+require_exact_threshold: false

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,15 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+require "yardstick/rake/measurement"
+
+Yardstick::Rake::Measurement.new(:yardstick_measure) do |measurement|
+  measurement.output = "/tmp/yard-results/measure.txt"
+end
+
+require "yardstick/rake/verify"
+require "yaml"
+
+options = YAML.load_file(".yardstick.yml")
+Yardstick::Rake::Verify.new(:yardstick_verify, options)

--- a/physical.gemspec
+++ b/physical.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "yardstick"
 end


### PR DESCRIPTION
This adds new Rake tasks that let us measure our YARD documentation coverage and quality:

```
bundle exec rake yardstick_measure
bundle exec rake yardstick_verify
```

It also adds a new runner to our CircleCI config to (1) verify YARD coverage is at least 50% and (2) store measurement results as an artifact. We can increase this threshold as coverage improves.