### PR TITLE
Add YARD docs for physical classes

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--protected
+--no-private
+--readme README.md
+--markup markdown
+--exclude test_support
+--exclude measured/density
+--exclude physical/types
+--exclude physical/property_readers
+'lib/**/*.rb' - '*.md'

--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Physical project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/physical/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Physical project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/friendlycart/physical/blob/main/CODE_OF_CONDUCT.md).

--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -3,25 +3,52 @@
 require 'measured'
 
 module Physical
+  # Represents a physical box which items can be packed into.
   class Box < Cuboid
+    # The default dimensions of this box when unspecified
     DEFAULT_LENGTH = BigDecimal::INFINITY
+
+    # The default maximum weight of this box when unspecified
     DEFAULT_MAX_WEIGHT = BigDecimal::INFINITY
 
-    attr_reader :inner_dimensions,
-                :inner_length,
-                :inner_width,
-                :inner_height,
-                :max_weight
+    # The inner length, width, and height of this box
+    # @return [Array<Measured::Length>]
+    attr_reader :inner_dimensions
 
-    def initialize(**args)
-      inner_dimensions = args.delete(:inner_dimensions) || []
-      max_weight = args.delete(:max_weight) || Measured::Weight(DEFAULT_MAX_WEIGHT, :g)
-      super(**args)
+    # The inner length of this box
+    # @return [Measured::Length]
+    attr_reader :inner_length
+
+    # The inner width of this box
+    # @return [Measured::Length]
+    attr_reader :inner_width
+
+    # The inner height of this box
+    # @return [Measured::Length]
+    attr_reader :inner_height
+
+    # The maximum weight this box can handle
+    # @return [Measured::Weight]
+    attr_reader :max_weight
+
+    # @param [Hash] kwargs ID, dimensions, weight, and properties
+    # @option kwargs [String] :id a unique identifier for this box
+    # @option kwargs [Array<Measured::Length>] :dimensions the outer length, width, and height of this box
+    # @option kwargs [Array<Measured::Length>] :inner_dimensions the inner length, width, and height of this box
+    # @option kwargs [Measured::Weight] :weight the weight of the box itself (excluding what's inside)
+    # @option kwargs [Measured::Weight] :max_weight the maximum weight this box can handle
+    # @option kwargs [Hash] :properties additional custom properties for this box
+    def initialize(**kwargs)
+      inner_dimensions = kwargs.delete(:inner_dimensions) || []
+      max_weight = kwargs.delete(:max_weight) || Measured::Weight(DEFAULT_MAX_WEIGHT, :g)
+      super(**kwargs)
       @inner_dimensions = fill_dimensions(Types::Dimensions[inner_dimensions])
       @inner_length, @inner_width, @inner_height = *@inner_dimensions
       @max_weight = Types::Weight[max_weight]
     end
 
+    # Calculates and returns this box's volume based on the inner dimensions
+    # @return [Measured::Volume]
     def inner_volume
       Measured::Volume(
         inner_dimensions.map { |d| d.convert_to(:cm).value }.reduce(1, &:*),
@@ -29,6 +56,7 @@ module Physical
       )
     end
 
+    # Returns true if the given item can fit inside this box
     # @param [Physical::Item] item
     # @return [Boolean]
     def item_fits?(item)

--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -3,11 +3,42 @@
 require 'measured'
 
 module Physical
+  # Represents a cube-shaped physical object with dimensions and weight.
   class Cuboid
     include PropertyReaders
 
-    attr_reader :dimensions, :length, :width, :height, :weight, :id, :properties
+    # A unique identifier for this cuboid
+    # @return [String]
+    attr_reader :id
 
+    # The length, width, and height of this cuboid
+    # @return [Array<Measured::Length>]
+    attr_reader :dimensions
+
+    # The length of this cuboid
+    # @return <Measured::Length>
+    attr_reader :length
+
+    # The width of this cuboid
+    # @return <Measured::Length>
+    attr_reader :width
+
+    # The height of this cuboid
+    # @return <Measured::Length>
+    attr_reader :height
+
+    # The weight of the cuboid itself (excluding what's inside)
+    # @return [Measured::Weight]
+    attr_reader :weight
+
+    # Additional custom properties for this cuboid
+    # @return [Hash]
+    attr_reader :properties
+
+    # @param [String] id a unique identifier for this cuboid
+    # @param [Array<Measured::Length>] dimensions the length, width, and height of this cuboid
+    # @param [Measured::Weight] weight the weight of the cuboid itself (excluding what's inside)
+    # @param [Hash] properties additional custom properties for this cuboid
     def initialize(id: nil, dimensions: [], weight: Measured::Weight(0, :g), properties: {})
       @id = id || SecureRandom.uuid
       @weight = Types::Weight[weight]
@@ -17,10 +48,14 @@ module Physical
       @properties = properties
     end
 
+    # Calculates and returns this cuboid's volume based on its dimensions
+    # @return [Measured::Volume]
     def volume
       Measured::Volume(dimensions.map { |d| d.convert_to(:cm).value }.reduce(1, &:*), :ml)
     end
 
+    # Calculates and returns this cuboid's density based on its volume and weight
+    # @return [Measured::Density]
     def density
       return Measured::Density(Float::INFINITY, :g_ml) if volume.value.zero?
       return Measured::Density(0.0, :g_ml) if volume.value.infinite?
@@ -28,6 +63,9 @@ module Physical
       Measured::Density(weight.convert_to(:g).value / volume.convert_to(:ml).value, :g_ml)
     end
 
+    # Returns true if the given object shares the same class and ID with this cuboid
+    # @param [Object] other
+    # @return [Boolean]
     def ==(other)
       other.is_a?(self.class) &&
         id == other&.id
@@ -35,6 +73,9 @@ module Physical
 
     private
 
+    # Fills an array with dimensions or with default values if unspecified
+    # @param [Array<Measured::Length>] dimensions
+    # @return [Array<Measured::Length>]
     def fill_dimensions(dimensions)
       dimensions.fill(dimensions.length..2) do |index|
         @dimensions[index] || Measured::Length(self.class::DEFAULT_LENGTH, :cm)

--- a/lib/physical/item.rb
+++ b/lib/physical/item.rb
@@ -1,13 +1,31 @@
 # frozen_string_literal: true
 
 module Physical
+  # Represents a physical item which can be packed into a box.
   class Item < Cuboid
+    # The default dimensions of this item when unspecified
     DEFAULT_LENGTH = 0
 
-    attr_reader :cost,
-                :sku,
-                :description
+    # The cost for this item
+    # @return [Money]
+    attr_reader :cost
 
+    # The SKU for this item
+    # @return [String]
+    attr_reader :sku
+
+    # A description for this item
+    # @return [String]
+    attr_reader :description
+
+    # @param [Hash] kwargs ID, dimensions, weight, and properties
+    # @option kwargs [String] :id a unique identifier for this item
+    # @option kwargs [Money] :cost the cost of this item
+    # @option kwargs [String] :sku the SKU for this item
+    # @option kwargs [String] :description a description for this item
+    # @option kwargs [Array<Measured::Length>] :dimensions the length, width, and height of this item
+    # @option kwargs [Measured::Weight] :weight the weight of this item
+    # @option kwargs [Hash] :properties additional custom properties for this item
     def initialize(**kwargs)
       @cost = Types::Money.optional[kwargs.delete(:cost)]
       @sku = kwargs.delete(:sku)

--- a/lib/physical/location.rb
+++ b/lib/physical/location.rb
@@ -3,28 +3,93 @@
 require 'carmen'
 
 module Physical
+  # Represents a physical location.
   class Location
     include PropertyReaders
 
+    # Possible address types for this location
     ADDRESS_TYPES = %w(residential commercial po_box).freeze
 
-    attr_reader :country,
-                :zip,
-                :region,
-                :city,
-                :name,
-                :address1,
-                :address2,
-                :address3,
-                :phone,
-                :fax,
-                :email,
-                :address_type,
-                :company_name,
-                :latitude,
-                :longitude,
-                :properties
+    # This location's country
+    # @return [Carmen::Country]
+    attr_reader :country
 
+    # This location's postal code
+    # @return [String]
+    attr_reader :zip
+
+    # This location's state or province
+    # @return [Carmen::Region]
+    attr_reader :region
+
+    # This location's city
+    # @return [String]
+    attr_reader :city
+
+    # This location's name (could be a person's name)
+    # @return [String]
+    attr_reader :name
+
+    # This location's address line 1
+    # @return [String]
+    attr_reader :address1
+
+    # This location's address line 2
+    # @return [String]
+    attr_reader :address2
+
+    # This location's address line 3
+    # @return [String]
+    attr_reader :address3
+
+    # This location's phone
+    # @return [String]
+    attr_reader :phone
+
+    # This location's fax
+    # @return [String]
+    attr_reader :fax
+
+    # This location's email
+    # @return [String]
+    attr_reader :email
+
+    # This location's address type (see {ADDRESS_TYPES})
+    # @return [String]
+    attr_reader :address_type
+
+    # This location's company name
+    # @return [String]
+    attr_reader :company_name
+
+    # This location's latitude
+    # @return [String]
+    attr_reader :latitude
+
+    # This location's longitude
+    # @return [String]
+    attr_reader :longitude
+
+    # Additional custom properties for this location
+    # @return [String]
+    attr_reader :properties
+
+    # @param [String] name the name of this location (could be a person's name)
+    # @param [String] company_name the name of the company at this location
+    # @param [String] address1 the first line of the address
+    # @param [String] address2 the second line of the address
+    # @param [String] address3 the third line of the address
+    # @param [String] city the city
+    # @param [String, Carmen::Region] region the state or province
+    # @param [String] zip the postal code
+    # @param [String, Carmen::Country] country the country
+    # @param [String] phone the phone number
+    # @param [String] fax the fax number
+    # @param [String] email the email address
+    # @param [String] address_type the type of address (see {ADDRESS_TYPES})
+    # @param [String] latitude the latitude at this location
+    # @param [String] longitude the longitude at this location
+    # @param [Hash] properties additional custom properties for this location
     def initialize(
       name: nil,
       company_name: nil,
@@ -72,18 +137,26 @@ module Physical
       @properties = properties
     end
 
+    # Returns true if this location's address type is "residential"
+    # @return [Boolean]
     def residential?
       @address_type == 'residential'
     end
 
+    # Returns true if this location's address type is "commercial"
+    # @return [Boolean]
     def commercial?
       @address_type == 'commercial'
     end
 
+    # Returns true if this location's address type is "po_box"
+    # @return [Boolean]
     def po_box?
       @address_type == 'po_box'
     end
 
+    # Returns a hash representation of this location.
+    # @return [Hash]
     def to_hash
       {
         country: country&.code,
@@ -102,6 +175,8 @@ module Physical
       }
     end
 
+    # Returns true if the given object's class and {#to_hash} match this location.
+    # @return [Boolean]
     def ==(other)
       other.is_a?(self.class) &&
         to_hash == other&.to_hash

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -1,10 +1,46 @@
 # frozen_string_literal: true
 
 module Physical
+  # Represents a physical package which has a container (box) and items.
   class Package
     extend Forwardable
-    attr_reader :id, :container, :items, :void_fill_density, :items_weight, :used_volume, :description
 
+    # A unique identifier for this package
+    # @return [String]
+    attr_reader :id
+
+    # The container ({Box}) for this package
+    # @return [Physical::Cuboid]
+    attr_reader :container
+
+    # The items contained by this package
+    # @return [Array<Physical::Item>]
+    attr_reader :items
+
+    # The density of the void fill in this package
+    # @return [Measured::Density]
+    attr_reader :void_fill_density
+
+    # The weight of the items in this package
+    # @return [Measured::Weight]
+    attr_reader :items_weight
+
+    # The total volume used by the items in this package
+    # @return [Measured::Volume]
+    attr_reader :used_volume
+
+    # The description for this package
+    # @return [String]
+    attr_reader :description
+
+    # @param [String] id a unique identifier for this package
+    # @param [Physical::Cuboid] container the container ({Box}) for this package
+    # @param [Array<Physical::Item>] items the items contained by this package
+    # @param [Measured::Density] void_fill_density the density of the void fill in this package
+    # @param [Array<Measured::Length>] dimensions the length, width, and height of this package's container
+    # @param [Measured::Weight] weight the weight of this package's container
+    # @param [String] description a description for this package
+    # @param [Hash] properties additional custom properties for this package's container
     def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Density(0, :g_ml), dimensions: nil, weight: nil, description: nil, properties: {})
       @id = id || SecureRandom.uuid
       @void_fill_density = Types::Density[void_fill_density]
@@ -16,8 +52,22 @@ module Physical
       @used_volume = @items.map(&:volume).reduce(Measured::Volume(0, :ml), &:+)
     end
 
+    # @!attribute [r] dimensions
+    #   The container's dimensions
+    # @!attribute [r] weight
+    #   The container's weight
+    # @!attribute [r] length
+    #   The container's length
+    # @!attribute [r] height
+    #   The container's height
+    # @!attribute [r] properties
+    #   The container's additional custom properties
+    # @!attribute [r] volume
+    #   The container's volume
     delegate [:dimensions, :width, :length, :height, :properties, :volume] => :container
 
+    # Adds an item to the package.
+    # @param [Physical::Item] other the item to add
     def <<(other)
       @items.add(other)
       @items_weight += other.weight
@@ -25,6 +75,8 @@ module Physical
     end
     alias_method :add, :<<
 
+    # Removes an item from the package.
+    # @param [Physical::Item] other the item to remove
     def >>(other)
       @items.delete(other)
       @items_weight -= other.weight
@@ -32,28 +84,37 @@ module Physical
     end
     alias_method :delete, :>>
 
+    # Sums container weight, items weight, and void fill weight and returns the total.
+    # @return [Measured::Weight]
     def weight
       container.weight + items_weight + void_fill_weight
     end
 
-    # Cost is optional. We will only return an aggregate if all items
-    # have cost defined. Otherwise we will return nil.
-    # @return Money
+    # Sums and returns the cost from all items in this package. Item cost is
+    # optional, therefore we only return a sum if *all* items have a cost.
+    # Otherwise, nil is returned.
+    # @return [Money, nil]
     def items_value
       items_cost = items.map(&:cost)
       items_cost.reduce(&:+) if items_cost.compact.size == items_cost.size
     end
 
+    # Calculates and returns the weight of the void fill in this package.
+    # @return [Measured::Weight]
     def void_fill_weight
       return Measured::Weight(0, :g) if container.volume.value.infinite?
 
       Measured::Weight(void_fill_density.convert_to(:g_ml).value * remaining_volume.convert_to(:ml).value, :g)
     end
 
+    # Calculates and returns remaining volume in this package.
+    # @return [Measured::Volume]
     def remaining_volume
       container.inner_volume - used_volume
     end
 
+    # Returns the density of this package based on its volume and weight.
+    # @return [Measured::Density]
     def density
       return Measured::Density(Float::INFINITY, :g_ml) if container.volume.value.zero?
       return Measured::Density(0.0, :g_ml) if container.volume.value.infinite?

--- a/lib/physical/pallet.rb
+++ b/lib/physical/pallet.rb
@@ -3,24 +3,52 @@
 require 'measured'
 
 module Physical
+  # Represents a physical pallet which holds boxes.
   class Pallet < Cuboid
+    # The default dimensions of this pallet when unspecified
     DEFAULT_LENGTH = BigDecimal::INFINITY
+
+    # The default maximum weight of this pallet when unspecified
     DEFAULT_MAX_WEIGHT = BigDecimal::INFINITY
 
+    # The maximum weight this pallet can handle
+    # @return [Measured::Weight]
     attr_reader :max_weight
 
-    def initialize(**args)
-      max_weight = args.delete(:max_weight) || Measured::Weight(DEFAULT_MAX_WEIGHT, :g)
-      super(**args)
+    # @param [Hash] kwargs ID, dimensions, weight, and properties
+    # @option kwargs [String] :id a unique identifier for this pallet
+    # @option kwargs [Array<Measured::Length>] :dimensions the length, width, and height of this pallet
+    # @option kwargs [Measured::Weight] :weight the weight of the pallet itself (excluding what's on top)
+    # @option kwargs [Measured::Weight] :max_weight the maximum weight this pallet can handle
+    # @option kwargs [Hash] :properties additional custom properties for this pallet
+    def initialize(**kwargs)
+      max_weight = kwargs.delete(:max_weight) || Measured::Weight(DEFAULT_MAX_WEIGHT, :g)
+      super(**kwargs)
       @max_weight = Types::Weight[max_weight]
     end
 
+    # @!method volume
+    #   @return [Measured::Volume] the volume of this pallet
     alias_method :inner_volume, :volume
+
+    # @!method dimensions
+    #   @return [Array<Measured::Length>] the dimensions of this pallet
     alias_method :inner_dimensions, :dimensions
+
+    # @!method length
+    #   @return [Measured::Length] the length of this pallet
     alias_method :inner_length, :length
+
+    # @!method width
+    #   @return [Measured::Length] the width of this pallet
     alias_method :inner_width, :width
+
+    # @!method height
+    #   @return [Measured::Length] the height of this pallet
     alias_method :inner_height, :height
 
+    # Returns true if the given package can fit on the pallet. Checks package
+    # dimensions and weight against pallet dimensions and max weight.
     # @param [Physical::Package] package
     # @return [Boolean]
     def package_fits?(package)

--- a/lib/physical/shipment.rb
+++ b/lib/physical/shipment.rb
@@ -1,16 +1,48 @@
 # frozen_string_literal: true
 
 module Physical
+  # Represents a physical shipment containing structures and/or packages.
   class Shipment
-    attr_reader :id,
-                :origin,
-                :destination,
-                :service_code,
-                :pallets,
-                :structures,
-                :packages,
-                :options
+    # A unique identifier for this shipment
+    # @return [String]
+    attr_reader :id
 
+    # This shipment's origin location
+    # @return [Physical::Location]
+    attr_reader :origin
+
+    # This shipment's destination location
+    # @return [Physical::Location]
+    attr_reader :destination
+
+    # The shipment carrier's service code
+    # @return [String]
+    attr_reader :service_code
+
+    # This shipment's pallets (DEPRECATED: use {#structures} instead)
+    # @return [Array<Physical::Pallet>]
+    attr_reader :pallets
+
+    # This shipment's structures (pallets, skids, etc.) which hold packages
+    # @return [Array<Physical::Structure>]
+    attr_reader :structures
+
+    # This shipment's packages which hold items
+    # @return [Array<Physical::Package>]
+    attr_reader :packages
+
+    # Additional custom options for this shipment
+    # @return [Hash]
+    attr_reader :options
+
+    # @param [String] id a unique identifier for this shipment
+    # @param [Physical::Location] origin the shipment's origin location
+    # @param [Physical::Location] destination the shipment's destination location
+    # @param [String] service_code the shipment carrier's service code
+    # @param [Array<Physical::Pallet>] pallets the shipment's pallets (DEPRECATED: use `structures` instead)
+    # @param [Array<Physical::Structure>] structures the shipment's structures (pallets, skids, etc.) which hold packages
+    # @param [Array<Physical::Package>] packages the shipment's packages (boxes) which hold items
+    # @param [Hash] options additional custom options for this shipment
     def initialize(id: nil, origin: nil, destination: nil, service_code: nil, pallets: [], structures: [], packages: [], options: {})
       @id = id || SecureRandom.uuid
       @origin = origin

--- a/lib/physical/structure.rb
+++ b/lib/physical/structure.rb
@@ -1,10 +1,36 @@
 # frozen_string_literal: true
 
 module Physical
+  # Represents a physical structure which has a container (pallet, skid, etc.) and packages.
   class Structure
     extend Forwardable
-    attr_reader :id, :container, :packages, :packages_weight, :used_volume
 
+    # A unique identifier for this structure
+    # @return [String]
+    attr_reader :id
+
+    # The container ({Pallet}) for this structure
+    # @return [Physical::Cuboid]
+    attr_reader :container
+
+    # The packages contained by this structure
+    # @return [Array<Physical::Package>]
+    attr_reader :packages
+
+    # The weight of the packages in this structure
+    # @return [Measured::Weight]
+    attr_reader :packages_weight
+
+    # The total volume used by the packages in this structure
+    # @return [Measured::Volume]
+    attr_reader :used_volume
+
+    # @param [String] id a unique identifier for this structure
+    # @param [Physical::Cuboid] container the container ({Pallet}) for this structure
+    # @param [Array<Physical::Package>] packages the packages contained by this structure
+    # @param [Array<Measured::Length>] dimensions the length, width, and height of this structure's container
+    # @param [Measured::Weight] weight the weight of this structure's container
+    # @param [Hash] properties additional custom properties for this package's container
     def initialize(id: nil, container: nil, packages: [], dimensions: nil, weight: nil, properties: {})
       @id = id || SecureRandom.uuid
       @container = container || Physical::Pallet.new(dimensions: dimensions || [], weight: weight || Measured::Weight(0, :g), properties: properties)
@@ -14,8 +40,22 @@ module Physical
       @used_volume = @packages.map(&:volume).reduce(Measured::Volume(0, :ml), &:+)
     end
 
+    # @!attribute [r] dimensions
+    #   The container's dimensions
+    # @!attribute [r] weight
+    #   The container's weight
+    # @!attribute [r] length
+    #   The container's length
+    # @!attribute [r] height
+    #   The container's height
+    # @!attribute [r] properties
+    #   The container's additional custom properties
+    # @!attribute [r] volume
+    #   The container's volume
     delegate [:dimensions, :width, :length, :height, :properties, :volume] => :container
 
+    # Adds a package to the structure.
+    # @param [Physical::Package] other the package to add
     def <<(other)
       @packages.add(other)
       @packages_weight += other.weight
@@ -23,6 +63,8 @@ module Physical
     end
     alias_method :add, :<<
 
+    # Removes a package from the structure.
+    # @param [Physical::Package] other the package to remove
     def >>(other)
       @packages.delete(other)
       @packages_weight -= other.weight
@@ -30,22 +72,29 @@ module Physical
     end
     alias_method :delete, :>>
 
+    # Sums container weight and packages weight and returns the total.
+    # @return [Measured::Weight]
     def weight
       container.weight + packages_weight
     end
 
-    # Cost is optional. We will only return an aggregate if all packages
-    # have items value defined. Otherwise we will return nil.
-    # @return Money
+    # Sums and returns the item cost from all packages in this structure.
+    # Item cost is optional, therefore we only return a sum if *all* packages
+    # return item cost. Otherwise, nil is returned.
+    # @return [Money, nil]
     def packages_value
       packages_cost = packages.map(&:items_value)
       packages_cost.reduce(&:+) if packages_cost.compact.size == packages_cost.size
     end
 
+    # Calculates and returns remaining volume in this structure.
+    # @return [Measured::Volume]
     def remaining_volume
       container.inner_volume - used_volume
     end
 
+    # Returns the density of this structure based on its volume and weight.
+    # @return [Measured::Density]
     def density
       return Measured::Density(Float::INFINITY, :g_ml) if container.volume.value.zero?
       return Measured::Density(0.0, :g_ml) if container.volume.value.infinite?

--- a/physical.gemspec
+++ b/physical.gemspec
@@ -27,9 +27,12 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", [">= 1.16", "< 3"]
   spec.add_development_dependency "factory_bot", "~> 6.2"
+  spec.add_development_dependency "rack"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "webrick"
+  spec.add_development_dependency "yard"
 end


### PR DESCRIPTION
This creates a `.yardopts` file with sensible defaults and adds YARD docs to the physical classes.